### PR TITLE
Split path at colon at most once

### DIFF
--- a/unixhttp.go
+++ b/unixhttp.go
@@ -54,7 +54,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	hostAndPath := strings.Split(u.Path, ":")
+	hostAndPath := strings.SplitN(u.Path, ":", 2)
 	if len(hostAndPath) < 2 {
 		usage()
 		os.Exit(1)


### PR DESCRIPTION
The HTTP path might contain a colon so preserve it
by spliting path on only once colon.
